### PR TITLE
User "jetty" should be created with proper home directory

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,6 +47,7 @@ node.set['jetty']['args'] =  (node['jetty']['args'] + ["-Djetty.port=#{node['jet
 # Create user and group
 
 user node['jetty']['user'] do
+  home  node['jetty']['home']
   shell '/bin/false'
   system true
   action :create


### PR DESCRIPTION
Before this fix, jetty user will be created with /home/jetty home directory.
Now the directory will be equal node['jetty']['home'] option
