### PR TITLE
group should use node['jetty']['user'] instead of hardcoded 'jetty'

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,7 +54,7 @@ user node['jetty']['user'] do
 end
 
 group node['jetty']['group'] do
-  members "jetty"
+  members node['jetty']['user']
   system true
   action :create
 end


### PR DESCRIPTION
Converge fails when changing node['jetty']['user'] to anything other than 'jetty'. This should fix it.
