### PR TITLE
copy 'modules' directory if jetty version is 9 or above

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -116,6 +116,21 @@ ruby_block 'Copy Jetty lib files' do
   end
 end
 
+ruby_block 'Copy Jetty module files' do
+  block do
+    Chef::Log.info "Copying Jetty module files into #{node['jetty']['home']}"
+    FileUtils.cp_r File.join(node['jetty']['extracted'], 'modules', ''), node['jetty']['home']
+    FileUtils.chown_R(node['jetty']['user'],node['jetty']['group'],File.join(node['jetty']['home'], 'modules', ''))
+    raise "Failed to copy Jetty modules" if Dir[File.join(node['jetty']['home'], 'modules', '*')].empty?
+  end
+
+  action :create
+
+  only_if do
+    Dir[File.join(node['jetty']['home'], 'modules', '*')].empty? and 
+    version >= 9
+  end
+end
 
 ruby_block 'Copy Jetty start.jar' do
   block do


### PR DESCRIPTION
Jetty 9 introduced a "modules" directory which needs to be installed into the jetty home directory.  This change will cause the cookbook to copy over this directory when the version is 9 or above. 
