### PR TITLE
allow file descriptor limit to be set for jetty

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,3 +49,7 @@ default['jetty']['syslog']['tag'] = ''
 
 default['jetty']['start_ini']['custom'] = false
 default['jetty']['start_ini']['content'] = []
+
+# open file descriptor limit for jetty process
+default['jetty']['fd_limit'] = 1024
+

--- a/templates/default/jetty-8.sh.erb
+++ b/templates/default/jetty-8.sh.erb
@@ -407,6 +407,8 @@ case "$ACTION" in
       exit
     fi
 
+    ulimit -n <%= node['jetty']['fd_limit'] %>
+
     if type start-stop-daemon > /dev/null 2>&1
     then
       unset CH_USER

--- a/templates/default/jetty-9.sh.erb
+++ b/templates/default/jetty-9.sh.erb
@@ -436,6 +436,8 @@ case "$ACTION" in
       exit
     fi
 
+    ulimit -n <%= node['jetty']['fd_limit'] %>
+
     if [ $UID -eq 0 ] && type start-stop-daemon > /dev/null 2>&1
     then
       unset CH_USER


### PR DESCRIPTION
adds a new attribute, node['jetty']['fd_limit'] which sets the open file descriptor limit for the jetty java process. Default value is 1024. 
