### PR TITLE
Add retry capability to jetty downloading

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,8 @@ default['jetty']['add_confs'] = []
 
 default['jetty']['version'] = '8.1.10.v20130312'
 default['jetty']['link'] = 'http://eclipse.org/downloads/download.php?file=/jetty/8.1.10.v20130312/dist/jetty-distribution-8.1.10.v20130312.tar.gz&r=1'
+default['jetty']['retries'] = 0 
+default['jetty']['retry_delay'] = 2
 default['jetty']['checksum'] = 'e966f87823adc323ce67e99485fea126b84fff5affdc28aa7526e40eb2ec1a5b' # SHA256
 
 default['jetty']['directory'] = '/usr/local/src'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,6 +82,8 @@ end
 remote_file node['jetty']['download'] do
   source   node['jetty']['link']
   checksum node['jetty']['checksum']
+  retries node['jetty']['retries'] 
+  retry_delay node['jetty']['retry_delay']
   mode     0644
 end
 


### PR DESCRIPTION
We have seen a number of failures from the mirror (ECONNRESET) when several nodes try to provision at once. This allows one to add a bit more resiliency to the cookbook... if one wants to. The default behavior is unchanged.
