### PR TITLE
Add the ability to set the numeric UID and GID of the jetty user/group

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ For more usage examples, have a look to the recipes in test/cookbooks/hipsnip-je
 ## Attributes
 
 * `node["jetty"]["user"]` - name of the jetty user, default "jetty".
+* `node["jetty"]["uid"]` - Numeric UID of the jetty user, default is to be dynamically allocated by the system.
 * `node["jetty"]["group"]` - name of the jetty group, default "jetty".
+* `node["jetty"]["gid"]` - Numeric GID of the jetty group, default is to be dynamically allocated by the system.
 * `node["jetty"]["home"]` - location of the home directory of jetty, default "/usr/share/jetty".
 * `node["jetty"]["port"]` - port number of where jetty listens, default 8080
 * `node["jetty"]["args"]` - arguments pass to jetty at startup , default [], e.g: ["jetty.logs=/var/log/jetty"].

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 default['jetty']['user'] = 'jetty'
+default['jetty']['uid'] = nil # Default behaviour is to allow the system to pick the UID dynamically
 default['jetty']['group'] = 'jetty'
+default['jetty']['gid'] = nil # Default behaviour is to allow the system to pick the GID dynamically
 default['jetty']['home'] = '/usr/share/jetty'
 default['jetty']['port'] = 8080
 # The default arguments to pass to jetty.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,12 +50,18 @@ user node['jetty']['user'] do
   home  node['jetty']['home']
   shell '/bin/false'
   system true
+  unless node['jetty']['uid'].nil?
+    uid node['jetty']['uid']
+  end
   action :create
 end
 
 group node['jetty']['group'] do
   members node['jetty']['user']
   system true
+  unless node['jetty']['gid'].nil?
+    gid node['jetty']['gid']
+  end
   action :create
 end
 


### PR DESCRIPTION
The current behavior of the cookbook (chef default) is to have these numeric IDs automatically assigned by the system. This is sometimes not desirable, since some other software and services (such as shared storage) relies on the numeric UIDs and one would need them to be consistent/predictable across all systems. 

This change allows this attribute to be specified, but keeps the default behavior the same. Has been tested to work both ways.
